### PR TITLE
fixed the faulty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This plugin ports the achievement groups and many other features of the [SteamHu
 Once installed it should just work out of the box.
 <br>
 To see if the plugin is working click the View my achievements button on a game page and see that there is a new tab called `ACHIEVEMENT GROUPS`.
-![Main interface](Images/main-view.png)
+![Main interface](images/main-view.png)
 
 ## Contributing
 


### PR DESCRIPTION
Renamed the "Images" folder at line 34 to "images", since there is no uppercase images folder
Fixes the broken image on the readme.md showing the usage for the SteamHunter extension